### PR TITLE
[SWT-65]: instance var & methods without senders

### DIFF
--- a/src/ExtremeProGaming/EPGBacklogArea.class.st
+++ b/src/ExtremeProGaming/EPGBacklogArea.class.st
@@ -110,16 +110,7 @@ EPGBacklogArea >> initialize [
 ]
 
 {
-	#category : #accessing,
-	#'squeak_changestamp' : 'jmetrikat 6/9/2024 17:55'
-}
-EPGBacklogArea >> isEPGBacklogArea [
-
-	^ true.
-]
-
-{
-	#category : #testing,
+	#category : #'events-processing',
 	#'squeak_changestamp' : 'HCH 6/19/2024 19:55'
 }
 EPGBacklogArea >> isFree [

--- a/src/ExtremeProGaming/EPGBacklogCard.class.st
+++ b/src/ExtremeProGaming/EPGBacklogCard.class.st
@@ -56,15 +56,6 @@ EPGBacklogCard >> moveToDone [
 
 {
 	#category : #'events-processing',
-	#'squeak_changestamp' : 'HCH 6/20/2024 01:04'
-}
-EPGBacklogCard >> prepareMoveToDone [
-
-	self toggleFocusCard.
-]
-
-{
-	#category : #'events-processing',
 	#'squeak_changestamp' : 'HCH 6/20/2024 00:50'
 }
 EPGBacklogCard >> process [

--- a/src/ExtremeProGaming/EPGCard.class.st
+++ b/src/ExtremeProGaming/EPGCard.class.st
@@ -487,24 +487,6 @@ EPGCard >> effectSize [
 
 {
 	#category : #accessing,
-	#'squeak_changestamp' : 'HCH 6/19/2024 22:03'
-}
-EPGCard >> effectText [
-
-	^ effectText.
-]
-
-{
-	#category : #accessing,
-	#'squeak_changestamp' : 'HCH 6/20/2024 01:05'
-}
-EPGCard >> effectText: aText [
-
-	effectText := aText.
-]
-
-{
-	#category : #accessing,
 	#'squeak_changestamp' : 'HCH 5/29/2024 20:46'
 }
 EPGCard >> facing [

--- a/src/ExtremeProGaming/EPGCard.class.st
+++ b/src/ExtremeProGaming/EPGCard.class.st
@@ -795,6 +795,15 @@ EPGCard >> mouseDown: anEvent [
 ]
 
 {
+	#category : #'mouse events',
+	#'squeak_changestamp' : 'sv 7/9/2024 19:10'
+}
+EPGCard >> moveToDone [
+
+	^ self subclassResponsibility.
+]
+
+{
 	#category : #accessing,
 	#'squeak_changestamp' : 'HCH 6/3/2024 09:49'
 }

--- a/src/ExtremeProGaming/EPGCard.class.st
+++ b/src/ExtremeProGaming/EPGCard.class.st
@@ -18,7 +18,7 @@ Class {
 		'frontend',
 		'gameBoard',
 		'focus',
-		'effectText',
+		'effectSelector',
 		'effect'
 	],
 	#category : #'ExtremeProGaming-UI',
@@ -202,11 +202,11 @@ EPGCard >> beBackend [
 
 {
 	#category : #accessing,
-	#'squeak_changestamp' : 'sv 6/16/2024 08:37'
+	#'squeak_changestamp' : 'sv 7/9/2024 20:30'
 }
 EPGCard >> beFocus [
 
-	focus := true.
+	self focus: true.
 ]
 
 {
@@ -238,11 +238,11 @@ EPGCard >> bePositive [
 
 {
 	#category : #accessing,
-	#'squeak_changestamp' : 'sv 6/16/2024 08:37'
+	#'squeak_changestamp' : 'sv 7/9/2024 20:31'
 }
 EPGCard >> beUnfocus [
 
-	focus := false.
+	self focus: false.
 ]
 
 {
@@ -460,20 +460,20 @@ EPGCard >> effect: anEPGEffect [
 
 {
 	#category : #accessing,
-	#'squeak_changestamp' : 'HCH 6/19/2024 22:03'
+	#'squeak_changestamp' : 'sv 7/9/2024 20:34'
 }
 EPGCard >> effectSelector [
 
-	^ effectText.
+	^ effectSelector.
 ]
 
 {
 	#category : #accessing,
-	#'squeak_changestamp' : 'HCH 6/19/2024 22:03'
+	#'squeak_changestamp' : 'sv 7/9/2024 20:34'
 }
 EPGCard >> effectSelector: aSelector [
 
-	effectText := aSelector.
+	effectSelector := aSelector.
 ]
 
 {
@@ -501,6 +501,24 @@ EPGCard >> facing [
 EPGCard >> facing: aSelector [
 
 	facing := aSelector.
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'sv 7/9/2024 20:29'
+}
+EPGCard >> focus [
+
+	^ focus.
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'sv 7/9/2024 20:29'
+}
+EPGCard >> focus: aBoolean [
+
+	focus := aBoolean.
 ]
 
 {
@@ -755,11 +773,11 @@ EPGCard >> isEPGStorypoint [
 
 {
 	#category : #accessing,
-	#'squeak_changestamp' : 'sv 6/16/2024 08:37'
+	#'squeak_changestamp' : 'sv 7/9/2024 20:32'
 }
 EPGCard >> isFocus [
 
-	^ focus.
+	^ self focus.
 ]
 
 {

--- a/src/ExtremeProGaming/EPGCostDisplay.class.st
+++ b/src/ExtremeProGaming/EPGCostDisplay.class.st
@@ -312,11 +312,11 @@ EPGCostDisplay >> isFrontend [
 
 {
 	#category : #positioning,
-	#'squeak_changestamp' : 'HCH 5/29/2024 21:43'
+	#'squeak_changestamp' : 'sv 7/9/2024 20:35'
 }
 EPGCostDisplay >> nonDebtCenter [
 
-	perTechnicalDebt = 0
+	self perTechnicalDebt = 0
 		ifTrue: [^ self center].
 	^ self debtCenter - (self width / 2@ 0).
 ]

--- a/src/ExtremeProGaming/EPGDnDArea.class.st
+++ b/src/ExtremeProGaming/EPGDnDArea.class.st
@@ -328,15 +328,6 @@ EPGDnDArea >> initializeVisibleArea [
 
 {
 	#category : #accessing,
-	#'squeak_changestamp' : 'jmetrikat 6/9/2024 17:54'
-}
-EPGDnDArea >> isEPGBacklogArea [
-
-	^ false.
-]
-
-{
-	#category : #accessing,
 	#'squeak_changestamp' : 'HCH 5/27/2024 17:57'
 }
 EPGDnDArea >> isEPGDnDArea [
@@ -427,17 +418,6 @@ EPGDnDArea >> returnStorypoints [
 		(storypoint hasProperty: #temporaryAdditional)
 			ifTrue: [self game gameBoard temporaryStorypointArea dropInMorph: storypoint]
 			ifFalse: [self game gameBoard regularStorypointArea dropInMorph: storypoint]].
-]
-
-{
-	#category : #border,
-	#'squeak_changestamp' : 'HCH 5/27/2024 17:14'
-}
-EPGDnDArea >> toggleBorder [
-
-	self borderVisible
-		ifTrue: [self removeBorder. ]
-		ifFalse: [self addBorder. ]
 ]
 
 {

--- a/src/ExtremeProGaming/EPGDnDMorph.class.st
+++ b/src/ExtremeProGaming/EPGDnDMorph.class.st
@@ -12,6 +12,24 @@ Class {
 }
 
 {
+	#category : #accessing,
+	#'squeak_changestamp' : 'sv 7/9/2024 20:38'
+}
+EPGDnDMorph >> droppable [
+
+	^ droppable.
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'sv 7/9/2024 20:38'
+}
+EPGDnDMorph >> droppable: aBoolean [
+
+	droppable := aBoolean.
+]
+
+{
 	#category : #'dragging/dropping',
 	#'squeak_changestamp' : 'sv 6/17/2024 14:59'
 }
@@ -32,20 +50,20 @@ EPGDnDMorph >> isEPGDnDMorph [
 
 {
 	#category : #'dragging/dropping',
-	#'squeak_changestamp' : 'JP 6/19/2024 21:35'
+	#'squeak_changestamp' : 'sv 7/9/2024 20:41'
 }
 EPGDnDMorph >> shouldDropOnMouseUp [
 
-	^ droppable.
+	^ self droppable.
 ]
 
 {
 	#category : #'dragging/dropping',
-	#'squeak_changestamp' : 'JP 6/19/2024 21:35'
+	#'squeak_changestamp' : 'sv 7/9/2024 20:41'
 }
 EPGDnDMorph >> shouldDropOnMouseUp: aBoolean [
 
-	droppable := aBoolean.
+	self droppable: aBoolean.
 ]
 
 {

--- a/src/ExtremeProGaming/EPGGame.class.st
+++ b/src/ExtremeProGaming/EPGGame.class.st
@@ -106,15 +106,6 @@ EPGGame >> addTemporary: aNumber [
 ]
 
 {
-	#category : #storypoints,
-	#'squeak_changestamp' : 'HCH 6/19/2024 00:07'
-}
-EPGGame >> addUnavailable: aNumber [
-
-	self gameBoard unavailableStorypointArea addStorypoints: aNumber.
-]
-
-{
 	#category : #sprints,
 	#'squeak_changestamp' : 'sv 6/24/2024 10:07'
 }
@@ -451,15 +442,6 @@ EPGGame >> numOfFeatureCardsInGame [
 
 {
 	#category : #storypoints,
-	#'squeak_changestamp' : 'HCH 6/18/2024 23:43'
-}
-EPGGame >> numOfPermanentStorypoints [
-
-	^ self numOfAvailableStorypoints - self numOfTemporaryStorypoints.
-]
-
-{
-	#category : #storypoints,
 	#'squeak_changestamp' : 'HCH 6/18/2024 22:45'
 }
 EPGGame >> numOfStorypoints [
@@ -509,7 +491,7 @@ EPGGame >> processBacklogAreaStorypoints [
 
 {
 	#category : #sprints,
-	#'squeak_changestamp' : 'HCH 6/23/2024 16:36'
+	#'squeak_changestamp' : 'sv 7/9/2024 18:29'
 }
 EPGGame >> processCards [
 
@@ -518,9 +500,9 @@ EPGGame >> processCards [
 	self processableCards do: [:card | 
 			self sprintEffects add: card effect. 
 			card process.
-			processedCards add: card].
-	processedCards size = 0 ifTrue: [self startOfRound: true].
-	processedCards do: [:card | card prepareMoveToDone].
+			processedCards add: card.].
+	processedCards size = 0 ifTrue: [self startOfRound: true.].
+	processedCards do: [:card | card toggleFocusCard.].
 	self processDebtToAdd: processedCards.
 ]
 
@@ -567,46 +549,6 @@ EPGGame >> processEventCard: anEventCard [
 EPGGame >> processableCards [
 
 	^ self occupiedAreas collect: [:area | area card] thenSelect: [:card | card canBeProcessed].
-]
-
-{
-	#category : #storypoints,
-	#'squeak_changestamp' : 'HCH 6/20/2024 20:10'
-}
-EPGGame >> removeAllAvailableStorypoints [
-
-	self gameBoard availableStorypointAreas do: [:area | area clearArea].
-]
-
-{
-	#category : #storypoints,
-	#'squeak_changestamp' : 'HCH 6/18/2024 22:45'
-}
-EPGGame >> removeAllStorypoints [
-
-	self gameBoard storyPointAreas do: [:area | area clearArea].
-]
-
-{
-	#category : #storypoints,
-	#'squeak_changestamp' : 'HCH 6/18/2024 22:56'
-}
-EPGGame >> removeAllTemporaryStorypoints [
-
-	| temporaryArea |
-	temporaryArea := self gameBoard temporaryStorypointArea.
- 	temporaryArea clearArea.
-]
-
-{
-	#category : #storypoints,
-	#'squeak_changestamp' : 'HCH 6/18/2024 22:56'
-}
-EPGGame >> removeAllUnavailableStorypoints [
-
-	| temporaryArea |
-	temporaryArea := self gameBoard unavailableStorypointArea.
- 	temporaryArea clearArea.
 ]
 
 {

--- a/src/ExtremeProGaming/EPGGameBoard.class.st
+++ b/src/ExtremeProGaming/EPGGameBoard.class.st
@@ -627,15 +627,6 @@ EPGGameBoard >> initializeSectionMorphs [
 
 {
 	#category : #initialization,
-	#'squeak_changestamp' : 'Philipp 6/21/2024 02:37'
-}
-EPGGameBoard >> initializeStartScreen [
-	
-	self addMorph: (EPGStartScreen newWithScore: self game class highScore)
-]
-
-{
-	#category : #initialization,
 	#'squeak_changestamp' : 'JP 6/19/2024 22:43'
 }
 EPGGameBoard >> initializeStorypointAreas [

--- a/src/ExtremeProGaming/EPGJSONParser.class.st
+++ b/src/ExtremeProGaming/EPGJSONParser.class.st
@@ -156,14 +156,14 @@ EPGJSONParser >> createEffect: aJSONCardFormatted [
 
 {
 	#category : #'card creation',
-	#'squeak_changestamp' : 'HCH 6/23/2024 14:20'
+	#'squeak_changestamp' : 'sv 7/9/2024 20:22'
 }
 EPGJSONParser >> createEventCard: aCardJsonFormatted [
 
 	^ EPGEventCard newWithTitle: (aCardJsonFormatted at: 'title') 
-					    description: (aCardJsonFormatted at: 'description') 
-					    effectText: (aCardJsonFormatted at: 'effect')
-					    iterationNumber: (aCardJsonFormatted at: 'number').
+		    description: (aCardJsonFormatted at: 'description') 
+		    effectText: (aCardJsonFormatted at: 'effect')
+		    iterationNumber: (aCardJsonFormatted at: 'number').
 ]
 
 {
@@ -223,11 +223,11 @@ EPGJSONParser >> decodeJson [
 
 {
 	#category : #accessing,
-	#'squeak_changestamp' : 'HCH 6/23/2024 14:46'
+	#'squeak_changestamp' : 'sv 7/9/2024 20:21'
 }
 EPGJSONParser >> eventCards [
 
-	^ (eventCards sort: [:cardA :cardB | cardA iterationNumber >= cardB iterationNumber]).
+	^ eventCards sort: [:cardA :cardB | cardA iterationNumber >= cardB iterationNumber].
 	
 ]
 

--- a/src/ExtremeProGaming/EPGJSONParser.class.st
+++ b/src/ExtremeProGaming/EPGJSONParser.class.st
@@ -123,16 +123,16 @@ EPGJSONParser >> createCard: aCardJsonFormatted [
 
 {
 	#category : #'card creation',
-	#'squeak_changestamp' : 'sv 7/7/2024 20:01'
+	#'squeak_changestamp' : 'sv 7/9/2024 18:30'
 }
 EPGJSONParser >> createCards [
 
 	| cards |
-	cards := (self jsonContent collect: [:card | self createCard: card]).
+	cards := (self jsonContent collect: [:card | self createCard: card.]).
 	self
-		featureCards: (cards select: [:card | card isEPGFeatureCard]) shuffled;
-		bugCards: (cards select: [:card | card isEPGBugCard]) shuffled;
-		eventCards: (cards select: [:card | card isEPGEventCard]).
+		featureCards: (cards select: [:card | card isEPGFeatureCard.]) shuffled;
+		bugCards: (cards select: [:card | card isEPGBugCard.]) shuffled;
+		eventCards: (cards select: [:card | card isEPGEventCard.]).
 ]
 
 {


### PR DESCRIPTION
(In order to avoid too much confusion, here is the refactoring regarding only these two topics)

**Methods without senders**
Removed all methods that are actually not used, the ones that are found by the linter now are false-positives.

**Instance var access without accessor**
Added all needed accessors.
Exception are Test-classes, here direct var access is allowed (is done so in tests given by this squeak image)